### PR TITLE
set suggester position relative to input's relative-positioned parent

### DIFF
--- a/gobotany/static/scripts/simplekey/SearchSuggest.js
+++ b/gobotany/static/scripts/simplekey/SearchSuggest.js
@@ -162,7 +162,7 @@ define([
     SearchSuggest.prototype.set_horizontal_position = function() {
         // Adjust the menu's horizontal position so it lines up with
         // the search box regardless of window width.
-        var box_position = this.search_box.offset();
+        var box_position = this.search_box.position();
         this.menu.css('left', (box_position.left - 3) + 'px');
     };
 

--- a/gobotany/static/scripts/util/suggester.js
+++ b/gobotany/static/scripts/util/suggester.js
@@ -88,7 +88,7 @@ define([
 
     Suggester.prototype.set_menu_position = function () {
         // Position the menu under the box.
-        var $input_box_offset = this.$input_box.offset();
+        var $input_box_position = this.$input_box.position();
         var input_box_left_padding = 0;
         if (this.align_menu_inside_input === "true") {
             // If the option to align the menu to the inside of a padded
@@ -97,9 +97,9 @@ define([
                 parseInt(this.$input_box.css('padding-left')) - 3;
         }
         this.$menu.css('left',
-                       $input_box_offset.left + input_box_left_padding);
+                       $input_box_position.left + input_box_left_padding);
         this.$menu.css('top',
-                       $input_box_offset.top + this.$input_box.outerHeight());
+                       $input_box_position.top + this.$input_box.outerHeight());
     };
 
     Suggester.prototype.handle_keys_up = function (e) {


### PR DESCRIPTION
If the suggester input and div are inside something that has position: relative, the div ends up in the wrong position. This fixes that, assuming that both the input and the div have the same relatively-positioned ancestor. I'm not sure if that's a valid assumption for Go Botany so you'll want to test it before merging.
