### PR TITLE
allow a character's pile to be blank in the admin

### DIFF
--- a/gobotany/core/models.py
+++ b/gobotany/core/models.py
@@ -108,7 +108,7 @@ class Character(models.Model):
     name = models.CharField(max_length=100)
     friendly_name = models.CharField(max_length=100)
     character_group = models.ForeignKey(CharacterGroup)
-    pile = models.ForeignKey('Pile', null=True, related_name='characters')
+    pile = models.ForeignKey('Pile', null=True, related_name='characters', blank=True)
     ease_of_observability = models.PositiveSmallIntegerField(null=True,
         blank=True, choices=zip(range(1, 6), range(1, 6)))
 


### PR DESCRIPTION
Without this change, if you go to the admin page for a "common" character (as opposed to a pile-specific one), you can't save it without setting a pile.
