### PR TITLE
Add index to support spelling suggestions

### DIFF
--- a/gobotany/search/search_indexes.py
+++ b/gobotany/search/search_indexes.py
@@ -43,7 +43,7 @@ class BaseIndex(indexes.SearchIndex):
 
     url = indexes.CharField(use_template=True,
                             template_name='search_result_url.txt')
-    suggestions = indexes.CharField()
+    textSpell = indexes.CharField()
 
     def read_queryset(self):
         """Bypass `index_queryset()` when we just need to read a model.
@@ -68,7 +68,7 @@ class BaseIndex(indexes.SearchIndex):
         """
         prepared_data = super(BaseIndex, self).prepare(obj)
         if 'text' in prepared_data:
-            prepared_data['suggestions'] = prepared_data['text']
+            prepared_data['textSpell'] = prepared_data['text']
         return prepared_data
 
 


### PR DESCRIPTION
The heroku websolr add-on supports providing spelling suggestions ("did you mean x?") with search results if there's an index named textSpell. This adds and populates that index.

See http://blog.websolr.com/post/2748574298/spellcheck-with-solr-spellcheckcomponent for more info about this. I actually had to contact websolr support and have them adjust solrconfig.xml so that the suggestion component would be enabled.

Once suggestions are being returned by solr, including them in search results is as simple as setting HAYSTACK_INCLUDE_SPELLING = True and doing something like this in the search template:

```
{% if suggestion %}
<p>Did you mean <a href=".?q={{suggestion}}">{{suggestion}}</a>?</p>
{% endif %}
```
