### PR TITLE
basic changes to get running on django 1.6

### DIFF
--- a/gobotany/dkey/import_csv.py
+++ b/gobotany/dkey/import_csv.py
@@ -1,8 +1,8 @@
 """Import CSV files related to the dichotomous key."""
 
-from gobotany import settings
-from django.core import management
-management.setup_environ(settings)
+import os
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "gobotany.settings")
+from django.conf import settings
 
 import argparse
 import csv

--- a/gobotany/settings.py
+++ b/gobotany/settings.py
@@ -172,6 +172,7 @@ APPEND_SLASH = False
 SMART_APPEND_SLASH = True
 ROOT_URLCONF = 'gobotany.urls'
 INTERNAL_IPS = ('127.0.0.1',)
+STATIC_ROOT = ''
 STATIC_URL = '/static/'
 STATICFILES_DIRS = [('', os.path.join(THIS_DIRECTORY, 'static'))]
 MEDIA_ROOT = os.path.join(THIS_DIRECTORY, 'media')
@@ -221,8 +222,6 @@ if 'WEBSOLR_URL' in os.environ:
     HAYSTACK_SOLR_URL = os.environ['WEBSOLR_URL']
 
 TINYMCE_JS_URL = "tiny_mce/tiny_mce.js"
-# With no local static root, what should we do with the following setting?
-# TINYMCE_JS_ROOT = os.path.join(STATIC_ROOT, "tiny_mce")
 
 # Use memcached for caching if Heroku provides MEMCACHIER_SERVERS, or if a
 # developer runs us locally with that environment variable set.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 from setuptools import find_packages
 
 requirements = [
-    'django==1.5.2',
+    'django==1.6.11',
 
     'Pillow==2.4.0',
     'South==0.7.6',
@@ -34,8 +34,7 @@ requirements = [
     'django-email-confirmation==0.2',
     'django-facebook-connect>=1.0.2',
     'django-recaptcha==0.0.6',
-    # Installed in a separate step pending Django dependency issues
-    'django-registration==0.9b1',
+    'django-registration-redux==1.2',
 
     # For storing images on S3.
 


### PR DESCRIPTION
Here are at least some of the changes needed to run on Django 1.6. They definitely need a bit more vetting; we don't use user registration so I'm not sure that the switch to django-registration-redux doesn't have side effects, and I don't have an environment set up for running the tests at the moment.