### PR TITLE
Fix bad select_related call in lit source edit

### DIFF
--- a/gobotany/editor/views.py
+++ b/gobotany/editor/views.py
@@ -402,7 +402,7 @@ def edit_lit_sources(request, dotted_datetime):
         tcvs = models.TaxonCharacterValue.objects.filter(
             taxon=taxon, character_value__character=character,
             ).select_related(
-            'taxon character_value character_value__character'
+                'taxon', 'character_value', 'character_value__character'
             )
         tcvlist.extend(tcvs)
 


### PR DESCRIPTION
The original select_related call signature here appears to no longer be valid in Django 1.8.
